### PR TITLE
add pagination to movies/tv pages

### DIFF
--- a/frontend/src/pages/MovieHome.jsx
+++ b/frontend/src/pages/MovieHome.jsx
@@ -5,7 +5,9 @@ import { toast } from 'react-toastify';
 import MovieAndTvSkeleton from './skeletons/MovieAndTvSkeleton';
 
 const MovieHome = () => {
+  const moviesPerPage = 12;
   const [moviesArr, setMoviesArr] = useState([]);
+  const [currPage, setCurrPage] = useState(1);
   const [loading, setLoading] = useState(false);
   const BACKDROP_IMG = 'https://image.tmdb.org/t/p/w500';
   const { id } = useParams();
@@ -14,6 +16,18 @@ const MovieHome = () => {
   const NOIMAGE =
     'https://images.unsplash.com/photo-1469982866068-278880140412?q=80&w=3570&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D';
 
+  const maxMoviePages = Math.ceil(moviesArr.length / moviesPerPage);
+  const startIndex = (currPage - 1) * moviesPerPage;
+  const endIndex = startIndex + moviesPerPage;
+  const currMovies = moviesArr.slice(startIndex, endIndex);
+
+  const previousPageIndex = () => {
+    setCurrPage(Math.max(currPage - 1, 1));
+  };
+  const nextPageIndex = () => {
+    setCurrPage(Math.min(currPage + 1, maxMoviePages));
+  };
+
   useEffect(() => {
     let ignore = false;
     if (!ignore) fetchMovies();
@@ -21,7 +35,7 @@ const MovieHome = () => {
     return () => (ignore = true);
   }, [id]);
 
-  const url = `https://api.themoviedb.org/3/movie/${id}?api_key=${process.env.REACT_APP_TMDB_KEY}&language=en-US&page=1`;
+  const url = `https://api.themoviedb.org/3/movie/${id}?api_key=${process.env.REACT_APP_TMDB_KEY}&language=en-US`;
 
   const fetchMovies = async () => {
     setLoading(true);
@@ -39,6 +53,8 @@ const MovieHome = () => {
     }
   };
 
+  console.log(moviesArr);
+
   return (
     <>
       {loading ? (
@@ -46,11 +62,11 @@ const MovieHome = () => {
       ) : (
         <div className="container w-full max-w-[1200px] mx-auto pt-24 px-2 md:text-xl">
           <h1 className="text-3xl font-bold text-center pb-12">{pageTitle}</h1>
-          <div className="flex flex-wrap gap-4">
-            {moviesArr.map((movie) => {
+          <div className="grid justify-around gap-[2em] md:grid-cols-2 lg:grid-cols-3 ">
+            {currMovies.map((movie) => {
               return (
                 <div
-                  className="relative lg:basis-[21%] mx-auto"
+                  className="relative mx-auto"
                   key={movie.id}
                   onClick={() => navigate(`/movie/${movie.id}`)}
                 >
@@ -72,7 +88,7 @@ const MovieHome = () => {
                       src={
                         movie.backdrop_path === null ? NOIMAGE : BACKDROP_IMG + movie.backdrop_path
                       }
-                      className=" mx-auto w-[300px] h-[300px] object-cover"
+                      className=" mx-auto w-[350px] h-[400px] object-cover"
                       loading="lazy"
                       alt={`${movie.title} image`}
                     />
@@ -83,6 +99,25 @@ const MovieHome = () => {
                 </div>
               );
             })}
+          </div>
+          <div className="text-center mt-10">
+            <button
+              className="p-4 hover:text-red-500 cursor-pointer"
+              onClick={previousPageIndex}
+              disabled={currPage === 1}
+            >
+              Previous
+            </button>
+            <span>
+              Page <span className="text-red-500">{currPage}</span> of {maxMoviePages}
+            </span>
+            <button
+              className="p-4 hover:text-red-500 cursor-pointer"
+              onClick={nextPageIndex}
+              disabled={currPage === maxMoviePages}
+            >
+              Next
+            </button>
           </div>
         </div>
       )}

--- a/frontend/src/pages/TvHome.jsx
+++ b/frontend/src/pages/TvHome.jsx
@@ -5,7 +5,9 @@ import { toast } from 'react-toastify';
 import MovieAndTvSkeleton from './skeletons/MovieAndTvSkeleton';
 
 const TvHome = () => {
+  const tvShowsPerPage = 12;
   const [tvShowArr, setTvShowArr] = useState([]);
+  const [currPage, setCurrPage] = useState(1);
   const [loading, setLoading] = useState(false);
   const BACKDROP_IMG = 'https://image.tmdb.org/t/p/w500';
   const { id } = useParams();
@@ -13,6 +15,18 @@ const TvHome = () => {
   const pageTitle = id.trim().toUpperCase().replace('_', ' ');
   const NOIMAGE =
     'https://images.unsplash.com/photo-1469982866068-278880140412?q=80&w=3570&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D';
+
+  const maxTvPages = Math.ceil(tvShowArr.length / tvShowsPerPage);
+  const startIndex = (currPage - 1) * tvShowsPerPage;
+  const endIndex = startIndex + tvShowsPerPage;
+  const currTvShows = tvShowArr.slice(startIndex, endIndex);
+
+  const previousPageIndex = () => {
+    setCurrPage(Math.max(currPage - 1, 1));
+  };
+  const nextPageIndex = () => {
+    setCurrPage(Math.min(currPage + 1, maxTvPages));
+  };
 
   useEffect(() => {
     let ignore = false;
@@ -46,11 +60,11 @@ const TvHome = () => {
       ) : (
         <div className="container w-full max-w-[1200px] mx-auto pt-24 px-2 md:text-xl">
           <h1 className="text-3xl font-bold text-center pb-12">{pageTitle}</h1>
-          <div className="flex flex-wrap gap-4">
-            {tvShowArr.map((show) => {
+          <div className="grid justify-around gap-[2em] md:grid-cols-2 lg:grid-cols-3 ">
+            {currTvShows.map((show) => {
               return (
                 <div
-                  className="relative lg:basis-[21%] mx-auto"
+                  className="relative mx-auto"
                   key={show.id}
                   onClick={() => navigate(`/tv/${show.id}`)}
                 >
@@ -84,6 +98,25 @@ const TvHome = () => {
                 </div>
               );
             })}
+          </div>
+          <div className="text-center mt-10">
+            <button
+              className="p-4 hover:text-red-500 cursor-pointer"
+              onClick={previousPageIndex}
+              disabled={currPage === 1}
+            >
+              Previous
+            </button>
+            <span>
+              Page <span className="text-red-500">{currPage}</span> of {maxTvPages}
+            </span>
+            <button
+              className="p-4 hover:text-red-500 cursor-pointer"
+              onClick={nextPageIndex}
+              disabled={currPage === maxTvPages}
+            >
+              Next
+            </button>
           </div>
         </div>
       )}


### PR DESCRIPTION
Add Pagination to Movie/TV Show Listings

Description:
This PR adds basic pagination to the movie and TV show list pages. Instead of loading all items at once, the app now fetches a limited number of items per page.

What’s Included:
- Added pagination controls (Next / Previous buttons)
- Handled loading and empty states
- Cleaned up UI to support paginated data

Benefits:
- Faster load times, especially with large datasets
- Better performance on slower devices
- Makes the app more scalable
- Cleaner user experience